### PR TITLE
Modify: change frontend date display

### DIFF
--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -77,7 +77,7 @@ function HomePage() {
                   <div className="job-details">
                     <p className="listing-content"> {job.address}</p>
                     <p className="listing-content"> 房型: {job.room_type}</p>
-                    <p className="listing-content"> {job.start_date} ~ {job.end_date}</p>
+                    <p className="listing-content"> {new Date(job.start_date).toLocaleDateString()} ~ {new Date(job.end_date).toLocaleDateString()}</p>
                     <p className="listing-people"> 所需人數: {job.people_needed}</p>
                   </div>
                 </div>

--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -87,7 +87,7 @@ function JobDetail() {
             <div className="room-type">
               住宿類型: {job.room_type}
             </div>
-            <div className="period">{job.start_date} ~ {job.end_date}</div>
+            <div className="period">{new Date(job.start_date).toLocaleDateString()} ~ {new Date(job.end_date).toLocaleDateString()}</div>
             <div className="positions">
               需求人數: {job.people_needed}人
             </div>


### PR DESCRIPTION
原本前端頁面的開始以及結束日期會有多餘時間，現在改成只呈現日期
<img width="1458" alt="截圖 2024-12-22 上午10 34 25" src="https://github.com/user-attachments/assets/421d56ae-e02a-4fb5-b3e5-575ae491c279" />
<img width="1450" alt="截圖 2024-12-22 上午10 35 50" src="https://github.com/user-attachments/assets/ba85953b-c7e8-403d-a2c3-339d2ce7f970" />
